### PR TITLE
Fix setDelataY uses correct ShapeManager method

### DIFF
--- a/MyCAD/EventHandling.cpp
+++ b/MyCAD/EventHandling.cpp
@@ -121,7 +121,7 @@ int EventHandling::setDelataX(int dx) const {
     }
 
 int EventHandling::setDelataY(int dy) const {
-    return  shapeManager->setDelataX(idx(), dy);
+    return  shapeManager->setDelataY(idx(), dy);
 }
 
 int EventHandling::getDelataX() const {


### PR DESCRIPTION
## Summary
- fix bug in `EventHandling::setDelataY` that incorrectly called `setDelataX`

## Testing
- `cmake ..` *(fails: Could not find `Qt6`)*

------
https://chatgpt.com/codex/tasks/task_e_683f5005246483299149f67609d9166d