### PR TITLE
Fix checkTab typo and add ShapeManager tests

### DIFF
--- a/MyCAD/EventHandling.cpp
+++ b/MyCAD/EventHandling.cpp
@@ -58,13 +58,13 @@ void EventHandling::mouseMoveEvent(QMouseEvent* event) {
 
 void EventHandling::mouseReleaseEvent(QMouseEvent* event) {
     if (event->button() == Qt::MiddleButton) { // Проверяем, что отпущена средняя кнопка мыши
-        if (chekTab()) {
+        if (checkTab()) {
             lastMousePosition = tabWidget->currentWidget()->mapFromGlobal(QCursor::pos());           
         }
         isDragging = false; // Устанавливаем флаг перетаскивания в false
     }
 
-    if (chekTab()) {
+    if (checkTab()) {
         QWidget* currentTab = tabWidget->currentWidget();
         if (currentTab) {
             currentTab->update();  // Вызов перерисовки активного виджета
@@ -88,7 +88,7 @@ bool EventHandling::event(QEvent* e) {
 }
 
 void EventHandling::handleHoverMoveEvent() {
-    if (chekTab()) {
+    if (checkTab()) {
        
         if (shapesNoEmpt()) {
             GetHandlePoint(); //Обработка выделения фигур и притягивания к центру handle
@@ -134,7 +134,7 @@ int EventHandling::getDelataY() const {
 
 void EventHandling::handleDrawing(QMouseEvent* event, bool& circleFlag) {
     if (tabWidget->rect().contains(event->pos())) {
-        if (chekTab()) {
+        if (checkTab()) {
 
             QPoint localPos = tabWidget->mapFromGlobal(event->globalPosition().toPoint());
             QRect tabBarRect = tabWidget->geometry();
@@ -174,7 +174,7 @@ void EventHandling::handleSelection(QMouseEvent* event, bool circleFlag) {
         selectShapes(event);
     }
 
-    if (chekTab()) {
+    if (checkTab()) {
         lastMousePosition = tabWidget->currentWidget()->mapFromGlobal(QCursor::pos());
     }
 
@@ -226,7 +226,7 @@ QPoint EventHandling::GetCurrPoint() {
 
 void EventHandling::selectShapes(QMouseEvent* event) {
     (void)event;
-    if (chekTab()) {
+    if (checkTab()) {
         QPoint newpoint = GetCurrPoint();
         for (const auto& shape : shapeManager->getShapes(idx())) {
             HandleType handle = shape->getHandleAt(newpoint);
@@ -242,7 +242,7 @@ void EventHandling::selectShapes(QMouseEvent* event) {
 
 void EventHandling::highlightShapes(QMouseEvent* event) {
     (void)event;
-    if (chekTab()) {
+    if (checkTab()) {
         QPoint newpoint = GetCurrPoint();
         bool isanyshapeselectedandhandled = false;
         if (!getShapes().empty()) {
@@ -270,7 +270,7 @@ void EventHandling::highlightShapes(QMouseEvent* event) {
 
 
 QPoint EventHandling::GetHandlePoint() {
-    if (chekTab())
+    if (checkTab())
     {
         for (const auto& shape : getShapes())
         {
@@ -290,7 +290,7 @@ QPoint EventHandling::GetHandlePoint() {
 }
 
 void EventHandling::highlightShapesUnderCursor() {
-    if (chekTab()) {
+    if (checkTab()) {
         QPoint newpoint = GetCurrPoint();
         bool isanyshapeselectedandhandled = false;
         
@@ -347,7 +347,7 @@ void EventHandling::updateShapePositions() {
 void EventHandling::updateGridPosition(const QPoint& delta)
 {
     // Проверка, что индекс корректный и вкладки существуют
-    if (chekTab()) {
+    if (checkTab()) {
      //   int currentIndex = tabWidget->currentIndex();
         // Обновляем значения смещения сетки на основе переданного delta
         shapeManager->setDelataX(idx(), delta.x());
@@ -377,7 +377,7 @@ void EventHandling::updateGridPosition(const QPoint& delta)
     }
 }
 
-bool EventHandling::chekTab() const {
+bool EventHandling::checkTab() const {
     bool result = false;
     if (tabWidget != nullptr) {
         int currentIndex = tabWidget->currentIndex();
@@ -404,7 +404,7 @@ void EventHandling::movingPush(HandleType handle, bool isselected)
 bool EventHandling::shapesNoEmpt()const
 {
     bool result = false;
-    if (chekTab()) {
+    if (checkTab()) {
        
         if (!getShapes().empty())
         {

--- a/MyCAD/EventHandling.h
+++ b/MyCAD/EventHandling.h
@@ -37,7 +37,7 @@ public:
     ~EventHandling();
     QPoint GetHandlePoint();
 protected:
-    bool chekTab() const;
+    bool checkTab() const;
     bool event(QEvent* e) override;
     bool isDragging = false;
     bool shapesNoEmpt()const;

--- a/MyCAD/MyCAD.cpp
+++ b/MyCAD/MyCAD.cpp
@@ -160,7 +160,7 @@ void MyCAD::onDrawCircle()
 void MyCAD::updateGridPosition(const QPoint& delta)
 {
     // Проверка, что индекс корректный и вкладки существуют
-    if (chekTab()) {    
+    if (checkTab()) {    
         // Обновляем значения смещения сетки на основе переданного delta
         setDelataX(delta.x());
         setDelataY(delta.y());
@@ -208,7 +208,7 @@ bool MyCAD::isDrawEnabled() const {
 
 // Вспомогательная функция для проверки активности текущей вкладки
 bool MyCAD::isTabActive() const {
-    return tabWidget && chekTab() && tabWidget->currentWidget();
+    return tabWidget && checkTab() && tabWidget->currentWidget();
 }
 
 void MyCAD::CrossCursorIn(QPainter& painter)
@@ -228,7 +228,7 @@ void MyCAD::CrossCursorHandle(QPainter& painter)
 
 void MyCAD::drawShapes(QPainter& painter) {
     // Проверяем, есть ли активная вкладка
-    if (!chekTab()) {
+    if (!checkTab()) {
         return;
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # MyCAD
+
+MyCAD is a simple CAD-like drawing application built with Qt 6.
+
+## Building
+
+```bash
+cmake -S MyCAD -B build
+cmake --build build
+```
+
+## Running
+
+Execute the generated `MyCAD` binary from the `build` directory.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.19)
+project(MyCADTests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
+find_package(GTest REQUIRED)
+
+include_directories(../MyCAD)
+
+add_executable(runTests
+    test_shapemanager.cpp
+    ../MyCAD/ShapeManager.cpp
+)
+
+target_link_libraries(runTests PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets GTest::gtest GTest::gtest_main)
+
+add_test(NAME runTests COMMAND runTests)

--- a/tests/test_shapemanager.cpp
+++ b/tests/test_shapemanager.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+#include <QVector>
+#include "ShapeManager.h"
+
+TEST(ShapeManager, DeltaSetters) {
+    ShapeManager manager;
+    TabData tab;
+    manager.addTab(tab);
+    EXPECT_EQ(manager.setDelataX(0, 5), 5);
+    EXPECT_EQ(manager.getDelataX(0), 5);
+    EXPECT_EQ(manager.setDelataY(0, 3), 3);
+    EXPECT_EQ(manager.getDelataY(0), 3);
+}
+
+TEST(ShapeManager, AddShape) {
+    ShapeManager manager;
+    TabData tab;
+    manager.addTab(tab);
+    EXPECT_TRUE(manager.getShapes(0).empty());
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- rename `chekTab` to `checkTab`
- rewrite README with build instructions
- add basic unit tests for `ShapeManager`

## Testing
- `cmake -S tests -B build_tests`
- `cmake --build build_tests`
- `./build_tests/runTests`


------
https://chatgpt.com/codex/tasks/task_e_683f5004d8508329b1daa74357ea5b85