### PR TITLE
Add view panning

### DIFF
--- a/MyCAD/EventHandling.cpp
+++ b/MyCAD/EventHandling.cpp
@@ -139,7 +139,7 @@ void EventHandling::handleDrawing(QMouseEvent* event, bool& circleFlag) {
             QPoint localPos = tabWidget->mapFromGlobal(event->globalPosition().toPoint());
             QRect tabBarRect = tabWidget->geometry();
             if (tabBarRect.contains(localPos)) {
-                QPoint newpoint = GetCurrPoint();
+                QPoint newpoint = GetWorldPoint();
 
                 if (clickpoint != QPoint(INT_MIN, INT_MIN)) {
                     if (currentDrawMode == DrawMode::Line) {
@@ -175,7 +175,7 @@ void EventHandling::handleSelection(QMouseEvent* event, bool circleFlag) {
     }
 
     if (checkTab()) {
-        lastMousePosition = tabWidget->currentWidget()->mapFromGlobal(QCursor::pos());
+        lastMousePosition = GetWorldPoint();
     }
 
     if (!isdraw && !circleFlag) {
@@ -224,10 +224,15 @@ QPoint EventHandling::GetCurrPoint() {
     return currentTab->mapFromGlobal(globalPos);
 }
 
+QPoint EventHandling::GetWorldPoint() {
+    QPoint local = GetCurrPoint();
+    return local - QPoint(getDelataX(), getDelataY());
+}
+
 void EventHandling::selectShapes(QMouseEvent* event) {
     (void)event;
     if (checkTab()) {
-        QPoint newpoint = GetCurrPoint();
+        QPoint newpoint = GetWorldPoint();
         for (const auto& shape : shapeManager->getShapes(idx())) {
             HandleType handle = shape->getHandleAt(newpoint);
             if (shape->getisSelected() && shape->isHandleSelected(handle, newpoint)) {
@@ -243,7 +248,7 @@ void EventHandling::selectShapes(QMouseEvent* event) {
 void EventHandling::highlightShapes(QMouseEvent* event) {
     (void)event;
     if (checkTab()) {
-        QPoint newpoint = GetCurrPoint();
+        QPoint newpoint = GetWorldPoint();
         bool isanyshapeselectedandhandled = false;
         if (!getShapes().empty()) {
             for (const auto& shape : shapeManager->getShapes(idx())) {
@@ -276,7 +281,7 @@ QPoint EventHandling::GetHandlePoint() {
         {
             if (shape->getisSelected()) {
                 shape->getHandle()->setInHandle(false);
-                QPoint newpoint = GetCurrPoint();
+                QPoint newpoint = GetWorldPoint();
                 shape->captureCursorForAllHandles(tabWidget, newpoint, shape->getPoints());
                 disableCursor = shape->getHandle()->getInHandle();
                 if (disableCursor) {
@@ -291,7 +296,7 @@ QPoint EventHandling::GetHandlePoint() {
 
 void EventHandling::highlightShapesUnderCursor() {
     if (checkTab()) {
-        QPoint newpoint = GetCurrPoint();
+        QPoint newpoint = GetWorldPoint();
         bool isanyshapeselectedandhandled = false;
         
         if (!shapeManager->getShapes(idx()).empty()) {
@@ -319,7 +324,7 @@ void EventHandling::highlightShapesUnderCursor() {
 
 void EventHandling::updateShapePositions() {
     if (!selShapes.empty() && !movingStarts.empty()) {
-        QPoint newpoint = GetCurrPoint();
+        QPoint newpoint = GetWorldPoint();
         QPoint delta = newpoint - lastMousePosition;
         for (std::size_t i = 0; i < selShapes.size(); i++) {
             //bool temp = selShapes[i]->getisSelected();
@@ -353,25 +358,9 @@ void EventHandling::updateGridPosition(const QPoint& delta)
         shapeManager->setDelataX(idx(), delta.x());
         shapeManager->setDelataY(idx(), delta.y());
   
-        if (isdraw && clickpoint != QPoint(INT_MIN, INT_MIN)) {
-            clickpoint = QPoint(clickpoint.x() + delta.x(), clickpoint.y() + delta.y());
-        }
-
-        // Перерисовываем текущий активный виджет
         QWidget* currentTab = tabWidget->currentWidget();
         if (currentTab) {
-            currentTab->update();  // Вызов перерисовки виджета
-        }
-       
-        if (!selShapes.empty()) {
-            for (const auto& shape : selShapes)
-            {
-                shape->move(delta);
-            }
-        }
-        // Рисуем фигуры только для активной вкладки
-        for (const auto& shape : getShapes()) {
-            shape->move(delta);
+            currentTab->update();
         }
 
     }

--- a/MyCAD/EventHandling.h
+++ b/MyCAD/EventHandling.h
@@ -42,6 +42,7 @@ protected:
     bool isDragging = false;
     bool shapesNoEmpt()const;
     QPoint GetCurrPoint();
+    QPoint GetWorldPoint();
     QPoint lastMousePosition;
     QTabWidget* tabWidget;
     void clearSelection();

--- a/MyCAD/MyCAD.cpp
+++ b/MyCAD/MyCAD.cpp
@@ -164,23 +164,9 @@ void MyCAD::updateGridPosition(const QPoint& delta)
         // Обновляем значения смещения сетки на основе переданного delta
         setDelataX(delta.x());
         setDelataY(delta.y());
-        if (isdraw && clickpoint != QPoint(INT_MIN, INT_MIN)) {
-            clickpoint = QPoint(clickpoint.x() + delta.x(), clickpoint.y() + delta.y());
-        }
-        // Перерисовываем текущий активный виджет
         QWidget* currentTab = tabWidget->currentWidget();
         if (currentTab) {
-            currentTab->update();  // Вызов перерисовки виджета
-        }        
-        if (!selShapes.empty()) {
-            for (const auto& shape : selShapes)
-            {
-                shape->move(delta);
-            }
-        }
-        // Рисуем фигуры только для активной вкладки
-        for (const auto& shape : getShapes()) {
-            shape->move(delta);
+            currentTab->update();
         }
 
     }
@@ -193,12 +179,18 @@ void MyCAD::drawGrid(QPainter& painter) {
 
 void MyCAD::DrawLine(QPainter& painter, QPoint localPos0) {
     if (!isDrawEnabled()) return;  // Проверка условий перенесена в отдельную функцию
-    drawingManager->drawLine(painter, localPos0, GetCurrPoint());
+    painter.save();
+    painter.translate(getDelataX(), getDelataY());
+    drawingManager->drawLine(painter, localPos0, GetWorldPoint());
+    painter.restore();
 }
 
 void MyCAD::DrawCircle(QPainter& painter, QPoint localPos0) {
     if (!isDrawEnabled()) return;  
-    drawingManager->drawCircle(painter, localPos0, GetCurrPoint());
+    painter.save();
+    painter.translate(getDelataX(), getDelataY());
+    drawingManager->drawCircle(painter, localPos0, GetWorldPoint());
+    painter.restore();
 }
 
 // Вспомогательная функция для проверки активности вкладки и флага isdraw
@@ -237,12 +229,14 @@ void MyCAD::drawShapes(QPainter& painter) {
     int delataX = getDelataX();
     int delataY = getDelataY();
     QPoint delta(delataX, delataY);
+    painter.save();
+    painter.translate(delta);
     QWidget* currentTab = tabWidget->widget(currentIndex);
     int widgetHeight = currentTab->height();
 
     // Отрисовка временных выделенных фигур, если мы не перетаскиваем объекты
     if (!isDragging && !selShapes.empty()) {
-        drawingManager->drawTemporaryShapes(painter, tmpShapes, selShapes, GetCurrPoint());
+        drawingManager->drawTemporaryShapes(painter, tmpShapes, selShapes, GetWorldPoint());
     }
 
     // Основная отрисовка фигур для текущей вкладки
@@ -254,6 +248,6 @@ void MyCAD::drawShapes(QPainter& painter) {
         }
         shape->draw(painter);
     }
-
+    painter.restore();
     heightwindow_prev = widgetHeight;
 }


### PR DESCRIPTION
## Summary
- enable viewport panning without altering shape coordinates
- handle cursor position in world space via `GetWorldPoint`
- translate painters when drawing shapes and during interactive drawing

## Testing
- `cmake -S tests -B build`
- `cmake --build build`
- `./build/runTests`


------
https://chatgpt.com/codex/tasks/task_e_683f5cb7e13c832990774f7d568c169d