### PR TITLE
Improve panning with view offset

### DIFF
--- a/MyCAD/EventHandling.cpp
+++ b/MyCAD/EventHandling.cpp
@@ -59,7 +59,7 @@ void EventHandling::mouseMoveEvent(QMouseEvent* event) {
 void EventHandling::mouseReleaseEvent(QMouseEvent* event) {
     if (event->button() == Qt::MiddleButton) { // Проверяем, что отпущена средняя кнопка мыши
         if (checkTab()) {
-            lastMousePosition = tabWidget->currentWidget()->mapFromGlobal(QCursor::pos());           
+            lastMousePosition = GetCurrPoint();
         }
         isDragging = false; // Устанавливаем флаг перетаскивания в false
     }
@@ -175,7 +175,7 @@ void EventHandling::handleSelection(QMouseEvent* event, bool circleFlag) {
     }
 
     if (checkTab()) {
-        lastMousePosition = tabWidget->currentWidget()->mapFromGlobal(QCursor::pos());
+        lastMousePosition = GetCurrPoint();
     }
 
     if (!isdraw && !circleFlag) {
@@ -221,7 +221,7 @@ void EventHandling::resetShapeColors() {
 QPoint EventHandling::GetCurrPoint() {
     QPoint globalPos = QCursor::pos();
     QWidget* currentTab = tabWidget->currentWidget();
-    return currentTab->mapFromGlobal(globalPos);
+    return currentTab->mapFromGlobal(globalPos) - QPoint(getDelataX(), getDelataY());
 }
 
 void EventHandling::selectShapes(QMouseEvent* event) {
@@ -353,25 +353,10 @@ void EventHandling::updateGridPosition(const QPoint& delta)
         shapeManager->setDelataX(idx(), delta.x());
         shapeManager->setDelataY(idx(), delta.y());
   
-        if (isdraw && clickpoint != QPoint(INT_MIN, INT_MIN)) {
-            clickpoint = QPoint(clickpoint.x() + delta.x(), clickpoint.y() + delta.y());
-        }
-
         // Перерисовываем текущий активный виджет
         QWidget* currentTab = tabWidget->currentWidget();
         if (currentTab) {
             currentTab->update();  // Вызов перерисовки виджета
-        }
-       
-        if (!selShapes.empty()) {
-            for (const auto& shape : selShapes)
-            {
-                shape->move(delta);
-            }
-        }
-        // Рисуем фигуры только для активной вкладки
-        for (const auto& shape : getShapes()) {
-            shape->move(delta);
         }
 
     }

--- a/MyCAD/MyCAD.cpp
+++ b/MyCAD/MyCAD.cpp
@@ -164,23 +164,10 @@ void MyCAD::updateGridPosition(const QPoint& delta)
         // Обновляем значения смещения сетки на основе переданного delta
         setDelataX(delta.x());
         setDelataY(delta.y());
-        if (isdraw && clickpoint != QPoint(INT_MIN, INT_MIN)) {
-            clickpoint = QPoint(clickpoint.x() + delta.x(), clickpoint.y() + delta.y());
-        }
         // Перерисовываем текущий активный виджет
         QWidget* currentTab = tabWidget->currentWidget();
         if (currentTab) {
             currentTab->update();  // Вызов перерисовки виджета
-        }        
-        if (!selShapes.empty()) {
-            for (const auto& shape : selShapes)
-            {
-                shape->move(delta);
-            }
-        }
-        // Рисуем фигуры только для активной вкладки
-        for (const auto& shape : getShapes()) {
-            shape->move(delta);
         }
 
     }
@@ -213,17 +200,20 @@ bool MyCAD::isTabActive() const {
 
 void MyCAD::CrossCursorIn(QPainter& painter)
 {
-    drawingManager->drawCrossCursorIn(painter, GetCurrPoint());
+    QPoint pos = GetCurrPoint() + QPoint(getDelataX(), getDelataY());
+    drawingManager->drawCrossCursorIn(painter, pos);
 }
 
 void MyCAD::CrossCursorOut(QPainter& painter)
 {
-    drawingManager->drawCrossCursorOut(painter, GetCurrPoint());
+    QPoint pos = GetCurrPoint() + QPoint(getDelataX(), getDelataY());
+    drawingManager->drawCrossCursorOut(painter, pos);
 }
 
 void MyCAD::CrossCursorHandle(QPainter& painter)
 {
-    drawingManager->drawCrossCursorOut(painter, GetHandlePoint());
+    QPoint pos = GetHandlePoint() + QPoint(getDelataX(), getDelataY());
+    drawingManager->drawCrossCursorOut(painter, pos);
 }
 
 void MyCAD::drawShapes(QPainter& painter) {
@@ -246,14 +236,12 @@ void MyCAD::drawShapes(QPainter& painter) {
     }
 
     // Основная отрисовка фигур для текущей вкладки
+    painter.save();
+    painter.translate(delta);
     for (const auto& shape : getShapes()) {
-
-        if (heightwindow_prev != 0) {
-            QPoint delta(0, widgetHeight - heightwindow_prev);
-            shape->move(delta);
-        }
         shape->draw(painter);
     }
+    painter.restore();
 
     heightwindow_prev = widgetHeight;
 }


### PR DESCRIPTION
## Summary
- stop modifying shapes when panning
- adjust current point calculation to account for view offset
- translate painter when drawing
- draw cursor using translated coordinates

## Testing
- `cmake -S MyCAD -B build` *(fails: could not find Qt6)*
- `cmake --build build` *(fails: no build files)*
- `cmake ..` in tests *(fails: could not find Qt6)*
- `cmake --build .` *(fails: no build files)*

------
https://chatgpt.com/codex/tasks/task_e_683f62815e3c83298dc0c5f26113508d